### PR TITLE
Add: custom handler wrapper and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 ```js
 {
   "ROOM_ID": $string
-  "message": $string
   "action": "sendMessage"
+  "message": $string
 }
 ```

--- a/lambdas/common/Responses.ts
+++ b/lambdas/common/Responses.ts
@@ -1,4 +1,9 @@
-const Responses = ({ statusCode, body }: { statusCode: number; body: object }) => {
+export interface CustomResponse {
+  statusCode: number
+  body: string | object
+}
+
+export const Responses = ({ statusCode, body }: CustomResponse) => {
   return {
     headers: {
       'Content-Type': 'application/json',
@@ -9,5 +14,3 @@ const Responses = ({ statusCode, body }: { statusCode: number; body: object }) =
     body: JSON.stringify(body),
   }
 }
-
-export default Responses

--- a/lambdas/common/SocketHandler.ts
+++ b/lambdas/common/SocketHandler.ts
@@ -14,7 +14,7 @@ export default class SocketHandler {
     const endpoint = `${domainName}/${stage}`
     const apiGatewayManager = new ApiGatewayManagementApi({
       apiVersion: '2018-11-29',
-      endpoint: 'http://localhost:3001',
+      endpoint,
     })
 
     return apiGatewayManager.postToConnection({ Data: message, ConnectionId }).promise()

--- a/lambdas/common/handlerWrapper.ts
+++ b/lambdas/common/handlerWrapper.ts
@@ -1,0 +1,26 @@
+import {
+  APIGatewayProxyHandler,
+  APIGatewayEvent,
+  Context,
+  Callback,
+  APIGatewayProxyResult,
+} from 'aws-lambda'
+import { Responses, CustomResponse } from './Responses'
+
+export type CustomLambdaHandler<TResult = CustomResponse> = (
+  event: APIGatewayEvent
+) => Promise<TResult>
+
+export const handlerWrapper = (handler: CustomLambdaHandler): APIGatewayProxyHandler => async (
+  event: APIGatewayEvent,
+  context: Context,
+  cb: Callback<APIGatewayProxyResult>
+) => {
+  try {
+    const { statusCode, body } = await handler(event)
+    return Responses({ statusCode, body })
+  } catch (err) {
+    console.log(err)
+    return Responses({ statusCode: 400, body: err })
+  }
+}

--- a/lambdas/connect.ts
+++ b/lambdas/connect.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
-import Responses from './common/Responses'
+import { Responses } from './common/Responses'
 
 export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId } = event.requestContext

--- a/lambdas/default.ts
+++ b/lambdas/default.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
-import Responses from './common/Responses'
+import { Responses } from './common/Responses'
 
 export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId } = event.requestContext

--- a/lambdas/disconnect.ts
+++ b/lambdas/disconnect.ts
@@ -1,35 +1,27 @@
 import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
-import Responses from './common/Responses'
 import Dynamo from './common/Dynamo'
+import { handlerWrapper } from './common/handlerWrapper'
 
-export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent) => {
+export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId } = event.requestContext
   const TableName = process.env.tableName as string
 
-  try {
-    const sessions = await Dynamo.getUsersByClientId({
-      connectionId: connectionId as string,
-      TableName,
-    })
+  const sessions = await Dynamo.getUsersByClientId({
+    connectionId: connectionId as string,
+    TableName,
+  })
 
-    console.log(sessions)
+  console.log(sessions)
 
-    await Promise.all(
-      sessions.map(({ connectionId, ROOM_ID }) =>
-        Dynamo.delete({
-          TableName,
-          connectionId,
-          ROOM_ID,
-        })
-      )
+  await Promise.all(
+    sessions.map(({ connectionId, ROOM_ID }) =>
+      Dynamo.delete({
+        TableName,
+        connectionId,
+        ROOM_ID,
+      })
     )
+  )
 
-    return Responses({ statusCode: 200, body: { message: 'deleted', connectedAt, connectionId } })
-  } catch (err) {
-    console.log(err)
-    return Responses({
-      statusCode: 400,
-      body: { message: 'disconnect failed', connectedAt, connectionId },
-    })
-  }
-}
+  return { statusCode: 200, body: { message: 'deleted', connectedAt, connectionId } }
+})

--- a/lambdas/enterRoom.ts
+++ b/lambdas/enterRoom.ts
@@ -1,24 +1,20 @@
-import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
-import Responses from './common/Responses'
+import { APIGatewayEvent } from 'aws-lambda'
 import Dynamo from './common/Dynamo'
+import { handlerWrapper } from './common/handlerWrapper'
 
-export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent) => {
+export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId } = event.requestContext
   const { ROOM_ID } = JSON.parse(event.body as string)
 
-  try {
-    await Dynamo.write({
-      ROOM_ID,
-      TableName: process.env.tableName as string,
-      connectionId: connectionId as string,
-      connectedAt: new Date(connectedAt as number).toISOString(),
-    })
+  await Dynamo.write({
+    ROOM_ID,
+    TableName: process.env.tableName as string,
+    connectionId: connectionId as string,
+    connectedAt: new Date(connectedAt as number).toISOString(),
+  })
 
-    return Responses({
-      statusCode: 200,
-      body: { message: `entered the room ${ROOM_ID}`, connectedAt, connectionId },
-    })
-  } catch (err) {
-    return Responses({ statusCode: 400, body: { message: 'there was an error entering the room' } })
+  return {
+    statusCode: 200,
+    body: { message: `entered the room ${ROOM_ID}`, connectedAt, connectionId },
   }
-}
+})

--- a/lambdas/leaveRoom.ts
+++ b/lambdas/leaveRoom.ts
@@ -1,23 +1,19 @@
-import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
-import Responses from './common/Responses'
+import { APIGatewayEvent } from 'aws-lambda'
 import Dynamo from './common/Dynamo'
+import { handlerWrapper } from './common/handlerWrapper'
 
-export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent) => {
+export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId } = event.requestContext
   const { ROOM_ID } = JSON.parse(event.body as string)
 
-  try {
-    await Dynamo.delete({
-      ROOM_ID,
-      connectionId: connectionId as string,
-      TableName: process.env.tableName as string,
-    })
+  await Dynamo.delete({
+    ROOM_ID,
+    connectionId: connectionId as string,
+    TableName: process.env.tableName as string,
+  })
 
-    return Responses({
-      statusCode: 200,
-      body: { message: `left the room ${ROOM_ID}`, connectedAt, connectionId },
-    })
-  } catch (err) {
-    return Responses({ statusCode: 400, body: { message: 'there was an error leaving the room' } })
+  return {
+    statusCode: 200,
+    body: { message: `left the room ${ROOM_ID}`, connectedAt, connectionId },
   }
-}
+})


### PR DESCRIPTION
## 변경사항 

### handlerWrapper 함수 추가 
**도입한 이유**
- 기존에 각각의 Lambda 핸들러에서 비동기 로직 실행 에러를 핸들링 하기 위해서 각각의 함수에서 `try, catch` 문이 중복되었음 
- `try, catch`로 인한 로직의 depth를 줄일 수 있음
- 중복되는 response 를 반환하는 코드 대신에 간결해진 return 문
- **CustomLambdaHandler**, **CustomResponse** 타입을 선언해서 handlerWrapper 로 감싸는 함수에 대해서도 argument, return 모두 type-safety 하게 자동완성 가능

**handlerWrapper.ts**
```ts
import {
  APIGatewayProxyHandler,
  APIGatewayEvent,
  Context,
  Callback,
  APIGatewayProxyResult,
} from 'aws-lambda'
import { Responses, CustomResponse } from './Responses'

// 일반적으로 작성하던 lambda handler 에 대한 타입을 지정 해 줌
// 결과값은 CustomResponse 
export type CustomLambdaHandler<TResult = CustomResponse> = (
  event: APIGatewayEvent
) => Promise<TResult> 

// CustomLambdaHandler 를 받아서, 실제로 Lambda 요청을 핸들링 할 APIGatewayProxyHandler 함수를  리턴하는 함수
export const handlerWrapper = (handler: CustomLambdaHandler): APIGatewayProxyHandler => async (
  event: APIGatewayEvent,
  context: Context,
  cb: Callback<APIGatewayProxyResult>
) => {
  try {
    const { statusCode, body } = await handler(event)
    return Responses({ statusCode, body })
  } catch (err) {
    console.log(err)
    return Responses({ statusCode: 400, body: err })
  }
}
```

**enterRoom.ts: handlerWrapper를 도입한 Lambda 함수 예시**
```ts
import { APIGatewayEvent } from 'aws-lambda'
import Dynamo from './common/Dynamo'
import { handlerWrapper } from './common/handlerWrapper'

export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
  const { connectedAt, connectionId } = event.requestContext
  const { ROOM_ID } = JSON.parse(event.body as string)

  await Dynamo.write({
    ROOM_ID,
    TableName: process.env.tableName as string,
    connectionId: connectionId as string,
    connectedAt: new Date(connectedAt as number).toISOString(),
  })

  return {
    statusCode: 200,
    body: { message: `entered the room ${ROOM_ID}`, connectedAt, connectionId },
  }
})

```