### PR TITLE
Modify: sendMessage

### DIFF
--- a/lambdas/common/Responses.ts
+++ b/lambdas/common/Responses.ts
@@ -10,7 +10,7 @@ export const Responses = ({ statusCode, body }: CustomResponse) => {
       'Access-Control-Allow-Methods': '*',
       'Access-Control-Allow-Origin': '*',
     },
-    statusCode: statusCode,
+    statusCode,
     body: JSON.stringify(body),
   }
 }

--- a/lambdas/common/SocketHandler.ts
+++ b/lambdas/common/SocketHandler.ts
@@ -4,7 +4,7 @@ interface SendToClientInput {
   domainName: string
   stage: string
   ConnectionId: string
-  message: string
+  message: string | object
 }
 
 export default class SocketHandler {
@@ -17,6 +17,8 @@ export default class SocketHandler {
       endpoint,
     })
 
-    return apiGatewayManager.postToConnection({ Data: message, ConnectionId }).promise()
+    return apiGatewayManager
+      .postToConnection({ Data: JSON.stringify(message), ConnectionId })
+      .promise()
   }
 }

--- a/lambdas/disconnect.ts
+++ b/lambdas/disconnect.ts
@@ -11,8 +11,6 @@ export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
     TableName,
   })
 
-  console.log(sessions)
-
   await Promise.all(
     sessions.map(({ connectionId, ROOM_ID }) =>
       Dynamo.delete({


### PR DESCRIPTION
## 변경사항

### lambdas/common/SocketHandler

```ts
    return apiGatewayManager
      .postToConnection({ Data: JSON.stringify(message), ConnectionId }) // 
      .promise()
```
- Data 의 자료형은 다음과 같다. 따라서 string 으로 변환하는 코드를 넣어줌
```ts
  export type Data = Buffer|Uint8Array|Blob|string;
```

### Todos
**채팅 메세지 | 위치 정보 타입 분리하는 작업**
**GraphQL API -> API Gateway | Websocket Lambda -> GraphQL API Mutation 단방향 흐름 결정하기**
1. sendMessage 람다 함수가 호출되었을 때, message 의 타입을 보고 객체일 때는 그냥 메세지만 보내고, string 일 때에는 채팅 메세지기 때문에 HTTP GraphQL API의 mutation 을 호출할 수 있다.
2. sendMessage 의 payload 인 message 키 값을 객체로 받아서 type 을 받도록 하면 더 안전한 체킹이 될 것 같다.

*ex)*
```ts
enum MessageType = {
  CHAT = "chat",
  LOCATION = "location"
}

type Payload = {
  message: {
    type: MessageType,
    data: string | object 
  }
}
```

3. 반대로 GraphQL API 에 sendChat mutation 이 들어오면 SocketHandler 클래스의 sendToClient 함수를 사용하면 어떨까 하는 방법. GraphQL HTTP Server 에서 API Gateway endpoint 에 postToConnection 함수를 트리거하는 방식으로 시도를 해볼 수 있다. 
