### PR TITLE
Add: SendToClient messageType

### DIFF
--- a/lambdas/common/SocketHandler.ts
+++ b/lambdas/common/SocketHandler.ts
@@ -4,12 +4,13 @@ interface SendToClientInput {
   domainName: string
   stage: string
   ConnectionId: string
-  message: string | object
+  message: string
+  messageType: string
 }
 
 export default class SocketHandler {
   static sendToClient(input: SendToClientInput) {
-    const { domainName, stage, ConnectionId, message } = input
+    const { domainName, stage, ConnectionId, message, messageType } = input
 
     const endpoint = `${domainName}/${stage}`
     const apiGatewayManager = new ApiGatewayManagementApi({
@@ -18,7 +19,7 @@ export default class SocketHandler {
     })
 
     return apiGatewayManager
-      .postToConnection({ Data: JSON.stringify(message), ConnectionId })
+      .postToConnection({ Data: JSON.stringify({ message, messageType }), ConnectionId })
       .promise()
   }
 }

--- a/lambdas/sendMessage.ts
+++ b/lambdas/sendMessage.ts
@@ -5,7 +5,7 @@ import { handlerWrapper } from './common/handlerWrapper'
 
 export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId, stage, domainName } = event.requestContext
-  const { ROOM_ID, message } = JSON.parse(event.body as string)
+  const { ROOM_ID, message, messageType } = JSON.parse(event.body as string)
 
   const users = await Dynamo.getUsersByRoomID({
     ROOM_ID,
@@ -15,10 +15,11 @@ export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const [peerUser] = users.filter(({ connectionId: foundUserId }) => foundUserId !== connectionId)
 
   await SocketHandler.sendToClient({
-    message: message as string,
-    ConnectionId: peerUser.connectionId,
-    stage,
     domainName: domainName as string,
+    stage,
+    ConnectionId: peerUser.connectionId,
+    message,
+    messageType,
   })
 
   return { statusCode: 200, body: { message: 'sent', connectedAt, connectionId } }


### PR DESCRIPTION
## 변경사항
- Frontend 측에서 messageType 을 구분하기 위해서 SendToClientInput 의 messageType 필드를 추가 함
- messageType = 'chat' | 'location'
```ts
interface SendToClientInput {
  domainName: string
  stage: string
  ConnectionId: string
  message: string
  messageType: string
}
```