### PR TITLE
Modify: SendToClientInput payload

### DIFF
--- a/lambdas/common/SocketHandler.ts
+++ b/lambdas/common/SocketHandler.ts
@@ -4,12 +4,12 @@ interface SendToClientInput {
   domainName: string
   stage: string
   ConnectionId: string
-  message: string | object
+  payload: { message: string; messageType: string; createdAt: string }
 }
 
 export default class SocketHandler {
-  static sendToClient(input: SendToClientInput) {
-    const { domainName, stage, ConnectionId, message } = input
+  static sendToClient(sendToClientData: SendToClientInput) {
+    const { domainName, stage, ConnectionId, payload } = sendToClientData
 
     const endpoint = `${domainName}/${stage}`
     const apiGatewayManager = new ApiGatewayManagementApi({
@@ -18,7 +18,7 @@ export default class SocketHandler {
     })
 
     return apiGatewayManager
-      .postToConnection({ Data: JSON.stringify(message), ConnectionId })
+      .postToConnection({ Data: JSON.stringify(payload), ConnectionId })
       .promise()
   }
 }

--- a/lambdas/sendMessage.ts
+++ b/lambdas/sendMessage.ts
@@ -5,7 +5,7 @@ import { handlerWrapper } from './common/handlerWrapper'
 
 export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId, stage, domainName } = event.requestContext
-  const { ROOM_ID, message } = JSON.parse(event.body as string)
+  const { ROOM_ID, message, messageType } = JSON.parse(event.body as string)
 
   const users = await Dynamo.getUsersByRoomID({
     ROOM_ID,
@@ -15,7 +15,7 @@ export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const [peerUser] = users.filter(({ connectionId: foundUserId }) => foundUserId !== connectionId)
 
   await SocketHandler.sendToClient({
-    message: message as string,
+    payload: { message, messageType, createdAt: new Date(connectedAt as number).toISOString() },
     ConnectionId: peerUser.connectionId,
     stage,
     domainName: domainName as string,


### PR DESCRIPTION
## 변경사항

### SocketHandler.sendToClient 메소드의 input 타입 변경

기존에 message 로 헷갈리던 속성명을 payload 로 바꾸고
payload 에 대한 타입을 지정 해 줌 
```ts
interface SendToClientInput {
  domainName: string
  stage: string
  ConnectionId: string
  payload: { message: string; messageType: string; createdAt: string }
}
``` 