### PR TITLE
Modify: 소켓 메세지 보완 

### DIFF
--- a/lambdas/common/Dynamo.ts
+++ b/lambdas/common/Dynamo.ts
@@ -24,7 +24,7 @@ interface UserSession {
 }
 
 export default class Dynamo {
-  static async getUsersByRoomID(dynamoInfo: DynamoDefaultInfo) {
+  static async getUsersByRoomID(dynamoInfo: DynamoDefaultInfo): Promise<UserSession[]> {
     const { ROOM_ID, TableName } = dynamoInfo
 
     const queried = await dynamoClient
@@ -47,7 +47,7 @@ export default class Dynamo {
     return queried.Items as UserSession[]
   }
 
-  static async getUsersByClientId(connectionInfo: UserConnectionInfo) {
+  static async getUsersByClientId(connectionInfo: UserConnectionInfo): Promise<UserSession[]> {
     const { TableName, connectionId } = connectionInfo
 
     const quried = await dynamoClient

--- a/lambdas/common/SocketHandler.ts
+++ b/lambdas/common/SocketHandler.ts
@@ -1,16 +1,11 @@
 import { ApiGatewayManagementApi } from 'aws-sdk'
+import { sendMessageInput } from '../sendMessage'
 
 interface SendToClientInput {
   domainName: string
   stage: string
   ConnectionId: string
-  payload: {
-    id: string
-    ROOM_ID: string
-    message: string
-    messageType: string
-    created_at: string
-  }
+  payload: sendMessageInput
 }
 
 export default class SocketHandler {

--- a/lambdas/disconnect.ts
+++ b/lambdas/disconnect.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyHandler, APIGatewayEvent } from 'aws-lambda'
+import { APIGatewayEvent } from 'aws-lambda'
 import Dynamo from './common/Dynamo'
 import { handlerWrapper } from './common/handlerWrapper'
 
@@ -11,15 +11,15 @@ export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
     TableName,
   })
 
-  await Promise.all(
-    sessions.map(({ connectionId, ROOM_ID }) =>
-      Dynamo.delete({
-        TableName,
-        connectionId,
-        ROOM_ID,
-      })
-    )
-  )
+  const thisDevice = sessions.find(
+    ({ connectionId: thisConnectionId }) => thisConnectionId === connectionId
+  )!
+
+  await Dynamo.delete({
+    TableName,
+    connectionId: thisDevice.connectionId,
+    ROOM_ID: thisDevice.ROOM_ID,
+  })
 
   return { statusCode: 200, body: { message: 'deleted', connectedAt, connectionId } }
 })

--- a/lambdas/sendMessage.ts
+++ b/lambdas/sendMessage.ts
@@ -3,23 +3,45 @@ import Dynamo from './common/Dynamo'
 import SocketHandler from './common/SocketHandler'
 import { handlerWrapper } from './common/handlerWrapper'
 
+interface ICoords {
+  latitude: number
+  longitude: number
+}
+
+export interface sendMessageInput {
+  id: string
+  user_id: string
+  ROOM_ID: string
+  message: string | ICoords
+  messageType: string
+  created_at: string
+}
+
 export const handler = handlerWrapper(async (event: APIGatewayEvent) => {
   const { connectedAt, connectionId, stage, domainName } = event.requestContext
-  const { id, ROOM_ID, message, messageType, created_at } = JSON.parse(event.body as string)
+  const { id, user_id, ROOM_ID, message, messageType, created_at }: sendMessageInput = JSON.parse(
+    event.body as string
+  )
 
-  const users = await Dynamo.getUsersByRoomID({
+  const connectedDevices = await Dynamo.getUsersByRoomID({
     ROOM_ID,
     TableName: process.env.tableName as string,
   })
 
-  const [peerUser] = users.filter(({ connectionId: foundUserId }) => foundUserId !== connectionId)
+  const devices = connectedDevices.filter(
+    ({ connectionId: foundUserId }) => foundUserId !== connectionId
+  )
 
-  await SocketHandler.sendToClient({
-    payload: { id, ROOM_ID, message, messageType, created_at },
-    ConnectionId: peerUser.connectionId,
-    stage,
-    domainName: domainName as string,
-  })
+  await Promise.all(
+    devices.map(({ connectionId }) =>
+      SocketHandler.sendToClient({
+        payload: { id, user_id, ROOM_ID, message, messageType, created_at },
+        ConnectionId: connectionId,
+        stage,
+        domainName: domainName as string,
+      })
+    )
+  )
 
   return { statusCode: 200, body: { message: 'sent', connectedAt, connectionId } }
 })


### PR DESCRIPTION
## sendMessageInput
- client 앱에서 messageType 과 user_id 를 보낼 수 있도록 수정

```ts
export interface sendMessageInput {
  id: string
  user_id: string
  ROOM_ID: string
  message: string | ICoords
  messageType: string
  created_at: string
}
```

## sendMessage 연결되어 있는 모든 기기에 보내도록 수정
```ts
  await Promise.all(
    devices.map(({ connectionId }) =>
      SocketHandler.sendToClient({
        payload: { id, user_id, ROOM_ID, message, messageType, created_at },
        ConnectionId: connectionId,
        stage,
        domainName: domainName as string,
      })
    )
  )
```

- client 앱에서 **authVar** 에 있는 id 랑 비교해서 id 가 다를 때에만 toast 띄우게 하기
- 여러 디바이스에서 동기적으로 메세지 받아 올 수 있음

## disconnect 함수 실행 될 때 실제 disconnect 액션을 발행한 기기만 소켓 끊기
```ts
  const thisDevice = sessions.find(
    ({ connectionId: thisConnectionId }) => thisConnectionId === connectionId
  )!

  await Dynamo.delete({
    TableName,
    connectionId: thisDevice.connectionId,
    ROOM_ID: thisDevice.ROOM_ID,
  })
```